### PR TITLE
FIX/RF: Add `version` column to projects database

### DIFF
--- a/migas_server/database.py
+++ b/migas_server/database.py
@@ -39,7 +39,7 @@ async def create_user_table(table: str) -> None:
             f'''
             CREATE TABLE IF NOT EXISTS "{validate_table(table)}" (
                 idx SERIAL NOT NULL PRIMARY KEY,
-                user_id UUID NOT NULL,
+                user_id UUID UNIQUE,
                 type VARCHAR(7) NOT NULL,
                 platform VARCHAR(8) NULL,
                 container VARCHAR(9) NOT NULL
@@ -115,7 +115,7 @@ async def insert_user(
             f'''
             INSERT INTO "{validate_table(table)}" (
                 user_id, type, platform, container
-            ) VALUES ($1, $2, $3, $4);''',
+            ) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING;''',
             user_id,
             user_type,
             platform,

--- a/migas_server/database.py
+++ b/migas_server/database.py
@@ -21,6 +21,7 @@ async def create_project_table(table: str) -> None:
             f'''
             CREATE TABLE IF NOT EXISTS "{validate_table(table)}" (
                 idx SERIAL NOT NULL PRIMARY KEY,
+                version VARCHAR(24) NOT NULL,
                 language VARCHAR(32) NOT NULL,
                 language_version VARCHAR(24) NOT NULL,
                 timestamp TIMESTAMPTZ NOT NULL,
@@ -73,6 +74,7 @@ async def create_project_tables(project) -> None:
 async def insert_project(
     table: str,
     *,
+    version: str,
     language: str,
     language_version: str,
     timestamp: DateTime,
@@ -86,13 +88,15 @@ async def insert_project(
         await conn.execute(
             f'''
             INSERT INTO "{validate_table(table)}" (
+                version,
                 language,
                 language_version,
                 timestamp,
                 session_id,
                 user_id,
                 status
-            ) VALUES ($1, $2, $3, $4, $5, $6);''',
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7);''',
+            version,
             language,
             language_version,
             timestamp,
@@ -127,6 +131,7 @@ async def insert_project_data(project: Project) -> bool:
     utable = f"{project.project}/users"
     await insert_project(
         project.project,
+        version=data['project_version'],
         language=data['language'],
         language_version=data['language_version'],
         timestamp=data['timestamp'],

--- a/migas_server/database.py
+++ b/migas_server/database.py
@@ -39,7 +39,7 @@ async def create_user_table(table: str) -> None:
             f'''
             CREATE TABLE IF NOT EXISTS "{validate_table(table)}" (
                 idx SERIAL NOT NULL PRIMARY KEY,
-                id UUID NOT NULL,
+                user_id UUID NOT NULL,
                 type VARCHAR(7) NOT NULL,
                 platform VARCHAR(8) NULL,
                 container VARCHAR(9) NOT NULL
@@ -78,7 +78,7 @@ async def insert_project(
     language: str,
     language_version: str,
     timestamp: DateTime,
-    session: str | None,
+    session_id: str | None,
     user_id: str | None,
     status: str,
 ) -> None:
@@ -100,7 +100,7 @@ async def insert_project(
             language,
             language_version,
             timestamp,
-            session,
+            session_id,
             user_id,
             status,
         )
@@ -114,9 +114,8 @@ async def insert_user(
         await conn.execute(
             f'''
             INSERT INTO "{validate_table(table)}" (
-                id, type, platform, container
+                user_id, type, platform, container
             ) VALUES ($1, $2, $3, $4);''',
-            table,
             user_id,
             user_type,
             platform,
@@ -135,7 +134,7 @@ async def insert_project_data(project: Project) -> bool:
         language=data['language'],
         language_version=data['language_version'],
         timestamp=data['timestamp'],
-        session=data['session'],
+        session_id=data['session_id'],
         user_id=data['context']['user_id'],
         status=data['process']['status'],
     )

--- a/migas_server/schema.py
+++ b/migas_server/schema.py
@@ -79,7 +79,7 @@ class Mutation:
             project_version=p.project_version,
             language=p.language,
             language_version=p.language_version,
-            session=p.session,
+            session_id=p.session_id,
             timestamp=now(),
             context=Context(
                 user_id=p.user_id,

--- a/migas_server/types.py
+++ b/migas_server/types.py
@@ -103,7 +103,7 @@ class Project:
     language_version: Version
     timestamp: DateTime
     # optional
-    session: UUID | None = None
+    session_id: UUID | None = None
     context: Context = None
     process: Process = Process
 
@@ -115,22 +115,24 @@ class ProjectInput:
     language: str = strawberry.field(description="Programming language of project")
     language_version: Version = strawberry.field(description="Programming language version")
     # optional
-    session: str = strawberry.field(description="Unique identifier for run", default=None)
-    # context args
-    user_id: str = strawberry.field(description="GitHub repository name", default=None)
-    user_type: 'User' = strawberry.field(
-        description="GitHub repository name", default=User.general
+    session_id: str = strawberry.field(
+        description="Unique identifier for telemetry session", default=None
     )
-    platform: str = strawberry.field(description="Unique identifier for run", default=None)
+    # context args
+    user_id: str = strawberry.field(description="Unique identifier for migas client", default=None)
+    user_type: 'User' = strawberry.field(
+        description="Identifier of user role", default=User.general
+    )
+    platform: str = strawberry.field(description="Client platform type", default=None)
     container: 'Container' = strawberry.field(
-        description="Unique identifier for run", default=Container.unknown
+        description="Check if client pings from inside a container", default=Container.unknown
     )
     # process args
     status: 'Status' = strawberry.field(
-        description="Unique identifier for run", default=Status.pending
+        description="For timeseries pings, the current process status", default=Status.pending
     )
     arguments: Arguments = strawberry.field(
-        description="Unique identifier for run", default_factory=lambda: "{}"
+        description="Client side arguments used", default_factory=lambda: "{}"
     )
 
 
@@ -139,7 +141,7 @@ async def serialize(data: dict) -> dict:
     for k, v in data.items():
         # TODO: Is this possible with PEP636?
         # I gave up trying it
-        if isinstance(v, _BaseVersion):
+        if isinstance(v, (_BaseVersion, UUID)):
             data[k] = str(v)
         elif isinstance(v, Enum):
             data[k] = v.name

--- a/migas_server/types.py
+++ b/migas_server/types.py
@@ -141,7 +141,7 @@ async def serialize(data: dict) -> dict:
     for k, v in data.items():
         # TODO: Is this possible with PEP636?
         # I gave up trying it
-        if isinstance(v, (_BaseVersion, UUID)):
+        if isinstance(v, _BaseVersion):
             data[k] = str(v)
         elif isinstance(v, Enum):
             data[k] = v.name


### PR DESCRIPTION
Closes #29 

This PR adds `version` which was missing from a project's database.

Additionally, this cleans up some naming inconsistencies:
- `session`/`session_id` are now `session_id`.
- `id` column in projects' users database was renamed to `user_id`.


## TODO
~~Avoid adding duplicate entries to projects' users database.~~