### PR TITLE
ENH: Add `is_ci` field to `add_project` resolver

### DIFF
--- a/migas_server/database.py
+++ b/migas_server/database.py
@@ -27,7 +27,8 @@ async def create_project_table(table: str) -> None:
                 timestamp TIMESTAMPTZ NOT NULL,
                 session_id UUID NULL,
                 user_id UUID NULL,
-                status VARCHAR(7) NOT NULL
+                status VARCHAR(7) NOT NULL,
+                is_ci BOOL NOT NULL
             );''',
         )
 
@@ -81,6 +82,7 @@ async def insert_project(
     session_id: str | None,
     user_id: str | None,
     status: str,
+    is_ci: bool,
 ) -> None:
     """Add to project table"""
     pool = await get_db_connection_pool()
@@ -94,8 +96,9 @@ async def insert_project(
                 timestamp,
                 session_id,
                 user_id,
-                status
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7);''',
+                status,
+                is_ci
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8);''',
             version,
             language,
             language_version,
@@ -103,6 +106,7 @@ async def insert_project(
             session_id,
             user_id,
             status,
+            is_ci,
         )
 
 
@@ -137,6 +141,7 @@ async def insert_project_data(project: Project) -> bool:
         session_id=data['session_id'],
         user_id=data['context']['user_id'],
         status=data['process']['status'],
+        is_ci=data['context']['is_ci'],
     )
     if data['context']['user_id'] is not None:
         await insert_user(

--- a/migas_server/schema.py
+++ b/migas_server/schema.py
@@ -86,6 +86,7 @@ class Mutation:
                 user_type=p.user_type,
                 platform=p.platform,
                 container=p.container,
+                is_ci=p.is_ci,
             ),
             process=Process(status=p.status),
         )

--- a/migas_server/types.py
+++ b/migas_server/types.py
@@ -93,6 +93,7 @@ class Context:
     user_type: User = User.general
     platform: str = "unknown"
     container: Container = Container.unknown
+    is_ci: bool = False
 
 
 @strawberry.type
@@ -126,6 +127,9 @@ class ProjectInput:
     platform: str = strawberry.field(description="Client platform type", default=None)
     container: 'Container' = strawberry.field(
         description="Check if client pings from inside a container", default=Container.unknown
+    )
+    is_ci: bool = strawberry.field(
+        description="Client is pinging from continous integration", default=False
     )
     # process args
     status: 'Status' = strawberry.field(


### PR DESCRIPTION
To monitor whether usage is "real"