### PR TITLE
RF: Shift database schema from `public` to `migas`

### DIFF
--- a/migas_server/app.py
+++ b/migas_server/app.py
@@ -10,7 +10,7 @@ from migas_server.connections import (
     get_redis_connection,
     get_requests_session,
 )
-from migas_server.models import create_tables
+from migas_server.models import init_db
 from migas_server.schema import SCHEMA
 
 
@@ -44,9 +44,9 @@ async def startup():
     app.cache = await get_redis_connection()
     # Connect to PostgreSQL
     app.db = await get_db_engine()
+    await init_db(app.db)
     # Establish aiohttp session
     app.requests = await get_requests_session()
-    await create_tables(app.db)
 
 
 @app.on_event("shutdown")


### PR DESCRIPTION
Tables were still being created under the `public` schema, because of a missing keyword on metadata assignment.

This change requires:
- A check when starting up to ensure the `migas` schema is present
- Appending `migas.` to tablenames when fetching via `Base.metadata.tables`