### PR TITLE
ENH: Make endpoint watchdog configurable via environmental variables

### DIFF
--- a/migas_server/schema.py
+++ b/migas_server/schema.py
@@ -138,7 +138,7 @@ class Watchdog(Extension):
                 data=None,
                 errors=[
                     GraphQLError(
-                        f'Request body ({len(body)}) exceeds maximum size ({self.MAX_REQUEST_BYTES})'
+                        f'Request body ({len(body)}) exceeds maximum size ({self.MAX_REQUEST_SIZE})'
                     )
                 ],
             )

--- a/migas_server/tests/test_server.py
+++ b/migas_server/tests/test_server.py
@@ -55,7 +55,7 @@ def test_graphql_add_project(query: str, client: TestClient) -> None:
 
 def test_graphql_big_request(client: TestClient) -> None:
     res = client.post(
-        "/graphql", json={'query': queries['add_project'].replace('javascript', 'x' * 300)}
+        "/graphql", json={'query': queries['add_project'].replace('javascript', 'x' * 450)}
     )
     assert res.status_code == 413
     errors = res.json()['errors']


### PR DESCRIPTION
This allows the endpoint watchdog knobs to be controlled via environmental variables. Some names were changed to better reflect their behavior.

This expands the default request body to be 450, up from 300.