### PR TITLE
FIX: Check for `REDIS_TLS_URL` before `MIGAS_REDIS_URI`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Migas is built with [FastAPI](https://fastapi.tiangolo.com/), [Strawberry](https
 
 | Service | Environmental Variable | Alternatives | Required |
 | ------- | ---------------------- | -------------| -------- |
-| redis | MIGAS_REDIS_URI | n/a | Yes
+| redis | REDIS_TLS_URI, MIGAS_REDIS_URI | n/a | At least one
 | postgres | DATABASE_URL | n/a | Yes
 | sqlalchemy | MIGAS_DEBUG | n/a | No
 

--- a/migas_server/connections.py
+++ b/migas_server/connections.py
@@ -25,8 +25,12 @@ async def get_redis_connection() -> redis.Redis:
     global MEM_CACHE
     if MEM_CACHE is None:
         print("Creating new redis connection")
-        if (uri := os.getenv("MIGAS_REDIS_URI")) is None:
-            raise ConnectionError("`MIGAS_REDIS_URI` is not set.")
+
+        # Check for both REDIS_TLS_URL (prioritized) and MIGAS_REDIS_URI
+        if (uri := os.getenv("REDIS_TLS_URL")) is None and (
+            uri := os.getenv("MIGAS_REDIS_URI")
+        ) is None:
+            raise ConnectionError("Redis environmental variable is not set.")
 
         rkwargs = {'decode_responses': True}
         if os.getenv("HEROKU_DEPLOYED") and uri.startswith('rediss://'):


### PR DESCRIPTION
Closes #33 - these rotations can lead to app downtime, so best to just prioritize them.