### PR TITLE
DB: Alter `status` field, expand project tables

### DIFF
--- a/alembic/versions/93c95bbf67a3_status_enum.py
+++ b/alembic/versions/93c95bbf67a3_status_enum.py
@@ -1,0 +1,60 @@
+"""status-enum
+
+Revision ID: 93c95bbf67a3
+Revises: 6d01a9e7093b
+Create Date: 2022-08-26 10:35:56.131795
+
+"""
+import sqlalchemy as sa
+import sqlalchemy.dialects.postgresql as psg
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '93c95bbf67a3'
+down_revision = '6d01a9e7093b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for project in get_tracked_projects():
+        # alter status column to use enum over varchar
+        status_type = psg.ENUM('R', 'C', 'F', 'S', name='status')
+        pt = create_adhoc_project_table(project, status_type)
+        op.alter_column(f'migas."{project}"', 'status', existing_typetype_=status_type)
+        conn.execute(pt.update().where(pt.c.status == 'success').values(status='C'))
+        conn.execute(pt.update().where(pt.c.status == 'pending').values(status='R'))
+        conn.execute(pt.update().where(pt.c.status == 'error').values(status='F'))
+        conn.commit()
+
+
+def downgrade() -> None:
+    projects = get_tracked_projects()
+    for project in projects:
+        status_type = psg.VARCHAR(7)
+        op.alter_column(project, 'status', type_=status_type)
+
+
+def get_tracked_projects() -> list[str]:
+    conn = op.get_bind()
+    projects = conn.execute(sa.text('select project from migas.projects')).scalars().fetchall()
+    return projects
+
+
+def create_adhoc_project_table(project, status_type=None) -> sa.sql.expression.TableClause:
+    pt = sa.table(
+        project,
+        sa.column('idx'),
+        sa.column('version'),
+        sa.column('language'),
+        sa.column('language_version'),
+        sa.column('timestamp'),
+        sa.column('session_id'),
+        sa.column('user_id'),
+        sa.column('status', status_type),
+        sa.column('is_ci'),
+        schema='migas',
+    )
+    return pt

--- a/migas_server/database.py
+++ b/migas_server/database.py
@@ -36,6 +36,9 @@ async def insert_project(
     session_id: str | None,
     user_id: str | None,
     status: str,
+    status_desc: str | None,
+    error_type: str | None,
+    error_desc: str | None,
     is_ci: bool,
 ) -> None:
     """Add to project table"""
@@ -50,6 +53,9 @@ async def insert_project(
                 'session_id': session_id,
                 'user_id': user_id,
                 'status': status,
+                'status_desc': status_desc,
+                'error_type': error_type,
+                'error_desc': error_desc,
                 'is_ci': is_ci,
             },
         )
@@ -91,6 +97,9 @@ async def ingest_project(project: Project) -> None:
         session_id=data['session_id'],
         user_id=data['context']['user_id'],
         status=data['process']['status'],
+        status_desc=data['process']['status_desc'],
+        error_type=data['process']['error_type'],
+        error_desc=data['process']['error_desc'],
         is_ci=data['context']['is_ci'],
     )
     if data['context']['user_id'] is not None:

--- a/migas_server/models.py
+++ b/migas_server/models.py
@@ -6,7 +6,7 @@ from sqlalchemy.dialects.postgresql import ENUM, UUID
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, AsyncSession
 from sqlalchemy.orm import declarative_base, relationship
 from sqlalchemy.sql import func
-from sqlalchemy.types import BOOLEAN, FLOAT, INTEGER, TIMESTAMP, VARCHAR, String
+from sqlalchemy.types import BOOLEAN, CHAR, FLOAT, INTEGER, TIMESTAMP, String
 
 SCHEMA = 'migas'
 
@@ -16,19 +16,19 @@ Base = declarative_base(metadata=MetaData(schema=SCHEMA))
 class Projects(Base):
     __tablename__ = "projects"
 
-    project = Column(VARCHAR(140), primary_key=True)  # 39 owner + "/" + 100 repository
+    project = Column(String(140), primary_key=True)  # 39 owner + "/" + 100 repository
 
 
 class Geolocs(Base):
     __tablename__ = "geolocs"
     __mapper_args__ = {"eager_defaults": True}
 
-    id = Column(String(64), primary_key=True)
-    continent = Column(VARCHAR(13), nullable=False)
-    country = Column(VARCHAR(56), nullable=False)
-    region = Column(VARCHAR(58), nullable=False)
-    city = Column(VARCHAR(58), nullable=False)
-    postal_code = Column(VARCHAR(10), nullable=False)
+    id = Column(CHAR(length=64), primary_key=True)
+    continent = Column(String(length=13), nullable=False)
+    country = Column(String(length=56), nullable=False)
+    region = Column(String(length=58), nullable=False)
+    city = Column(String(length=58), nullable=False)
+    postal_code = Column(String(length=10), nullable=False)
     latitude = Column(FLOAT(), nullable=False)
     longitude = Column(FLOAT(), nullable=False)
 
@@ -38,9 +38,9 @@ class Project(Base):
     __mapper_args__ = {"eager_defaults": True}
 
     idx = Column(INTEGER, primary_key=True)
-    version = Column(VARCHAR(24), nullable=False)
-    language = Column(VARCHAR(32), nullable=False)
-    language_version = Column(VARCHAR(24), nullable=False)
+    version = Column(String(length=24), nullable=False)
+    language = Column(String(length=32), nullable=False)
+    language_version = Column(String(length=24), nullable=False)
     timestamp = Column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now())
     session_id = Column(UUID)
     user_id = Column(UUID)  # relationship
@@ -54,9 +54,9 @@ class ProjectUsers(Base):
 
     idx = Column(INTEGER, primary_key=True)
     user_id = Column(UUID, unique=True)
-    user_type = Column(VARCHAR(7), nullable=False)
-    platform = Column(VARCHAR(8))
-    container = Column(VARCHAR(9), nullable=False)
+    user_type = Column(String(length=7), nullable=False)
+    platform = Column(String(length=8))
+    container = Column(String(length=9), nullable=False)
 
 
 geolocs = Geolocs.__table__

--- a/migas_server/models.py
+++ b/migas_server/models.py
@@ -2,7 +2,7 @@ from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 
 from sqlalchemy import Column, MetaData, Table
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import ENUM, UUID
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, AsyncSession
 from sqlalchemy.orm import declarative_base, relationship
 from sqlalchemy.sql import func
@@ -44,7 +44,7 @@ class Project(Base):
     timestamp = Column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now())
     session_id = Column(UUID)
     user_id = Column(UUID)  # relationship
-    status = Column(VARCHAR(7), nullable=False)
+    status = Column(ENUM('R', 'C', 'F', 'S', name='status'), nullable=False)
     is_ci = Column(BOOLEAN, nullable=False)
 
 
@@ -138,8 +138,6 @@ async def populate_base(conn: AsyncConnection) -> None:
 
         for project in await query_projects():
             await get_project_tables(project)
-
-    return Base
 
 
 async def init_db(engine: AsyncEngine) -> None:

--- a/migas_server/models.py
+++ b/migas_server/models.py
@@ -45,6 +45,9 @@ class Project(Base):
     session_id = Column(UUID)
     user_id = Column(UUID)  # relationship
     status = Column(ENUM('R', 'C', 'F', 'S', name='status'), nullable=False)
+    status_desc = Column(String)
+    error_type = Column(String)
+    error_desc = Column(String)
     is_ci = Column(BOOLEAN, nullable=False)
 
 

--- a/migas_server/schema.py
+++ b/migas_server/schema.py
@@ -92,7 +92,12 @@ class Mutation:
                 container=p.container,
                 is_ci=p.is_ci,
             ),
-            process=Process(status=p.status),
+            process=Process(
+                status=p.status,
+                status_desc=p.status_desc,
+                error_type=p.error_type,
+                error_desc=p.error_desc,
+            ),
         )
 
         fetched = await fetch_project_info(p.project)

--- a/migas_server/schema.py
+++ b/migas_server/schema.py
@@ -73,6 +73,10 @@ class Mutation:
     @strawberry.mutation
     async def add_project(self, p: ProjectInput, info: Info) -> JSON:
 
+        # validate project
+        if not p.project or '/' not in p.project:
+            raise Exception("Invalid project specified.")
+
         # convert to Project and set defaults
         project = Project(
             project=p.project,

--- a/migas_server/types.py
+++ b/migas_server/types.py
@@ -67,12 +67,17 @@ class User(Enum):
 @strawberry.enum
 class Status(Enum):
     R = 'running'
+    running = strawberry.enum_value('running')
     C = 'completed'
+    completed = strawberry.enum_value('completed')
     F = 'failed'
+    failed = strawberry.enum_value('failed')
     S = 'suspended'
-    pending = strawberry.enum_value('R', deprecation_reason="Changed to `running`")
-    success = strawberry.enum_value('C', deprecation_reason="Changed to `completed`")
-    error = strawberry.enum_value('F', deprecation_reason="Changed to `failed`")
+    suspended = strawberry.enum_value('suspended')
+
+    pending = strawberry.enum_value('running', deprecation_reason="Changed to `running`")
+    success = strawberry.enum_value('completed', deprecation_reason="Changed to `completed`")
+    error = strawberry.enum_value('error', deprecation_reason="Changed to `failed`")
 
 
 # @strawberry.type

--- a/migas_server/types.py
+++ b/migas_server/types.py
@@ -93,6 +93,9 @@ class Status(Enum):
 @strawberry.type
 class Process:
     status: Status = Status.pending
+    status_desc: str | None = None
+    error_type: str | None = None
+    error_desc: str | None = None
     # args: Arguments = "{}"
 
 
@@ -144,9 +147,12 @@ class ProjectInput:
     status: 'Status' = strawberry.field(
         description="For timeseries pings, the current process status", default=Status.R
     )
-    arguments: Arguments = strawberry.field(
-        description="Client side arguments used", default_factory=lambda: "{}"
-    )
+    status_desc: str = strawberry.field(description="Description of status ping", default=None)
+    error_type: str = strawberry.field(description="Type of error encountered", default=None)
+    error_desc: str = strawberry.field(description="Description of error", default=None)
+    # arguments: Arguments = strawberry.field(
+    #     description="Client side arguments used", default_factory=lambda: "{}"
+    # )
 
 
 async def serialize(data: dict) -> dict:

--- a/migas_server/types.py
+++ b/migas_server/types.py
@@ -66,9 +66,13 @@ class User(Enum):
 
 @strawberry.enum
 class Status(Enum):
-    pending = 2
-    success = 0
-    error = 1
+    running = 'R'
+    completed = 'C'
+    failed = 'F'
+    suspended = 'S'
+    pending = strawberry.enum_value('R', deprecation_reason="Changed to `running`")
+    success = strawberry.enum_value('C', deprecation_reason="Changed to `completed`")
+    error = strawberry.enum_value('F', deprecation_reason="Changed to `failed`")
 
 
 # @strawberry.type
@@ -133,7 +137,7 @@ class ProjectInput:
     )
     # process args
     status: 'Status' = strawberry.field(
-        description="For timeseries pings, the current process status", default=Status.pending
+        description="For timeseries pings, the current process status", default=Status.running
     )
     arguments: Arguments = strawberry.field(
         description="Client side arguments used", default_factory=lambda: "{}"

--- a/migas_server/types.py
+++ b/migas_server/types.py
@@ -66,10 +66,10 @@ class User(Enum):
 
 @strawberry.enum
 class Status(Enum):
-    running = 'R'
-    completed = 'C'
-    failed = 'F'
-    suspended = 'S'
+    R = 'running'
+    C = 'completed'
+    F = 'failed'
+    S = 'suspended'
     pending = strawberry.enum_value('R', deprecation_reason="Changed to `running`")
     success = strawberry.enum_value('C', deprecation_reason="Changed to `completed`")
     error = strawberry.enum_value('F', deprecation_reason="Changed to `failed`")
@@ -137,7 +137,7 @@ class ProjectInput:
     )
     # process args
     status: 'Status' = strawberry.field(
-        description="For timeseries pings, the current process status", default=Status.running
+        description="For timeseries pings, the current process status", default=Status.R
     )
     arguments: Arguments = strawberry.field(
         description="Client side arguments used", default_factory=lambda: "{}"


### PR DESCRIPTION
Starts the implementation of #43 

- Changes project `status` to be an enum with possible values:
  - `C (completed)` / `F (failed)` / `S (suspended)` / `R (running)`
  - Deprecates previously supported values: `pending` / `success` / `error`
- Sets default to `R`

## TODO
- [ ] Add `status_desc` column
- [ ] Add `error` column
- [ ] Add `error_desc` column